### PR TITLE
feat: forward cli args

### DIFF
--- a/src/bin/nps.js
+++ b/src/bin/nps.js
@@ -6,7 +6,13 @@ import runPackageScript from '../index'
 import parse from '../bin-utils/parser'
 
 const FAIL_CODE = 1
-const {argv, psConfig} = parse(process.argv.slice(2)) || {}
+
+const args = process.argv.slice(2)
+const indexOfCommand = args.findIndex(arg => !arg.startsWith('-'))
+const preCommandFlags = args.slice(0, indexOfCommand + 1)
+const postCommandFlags = args.slice(indexOfCommand + 1)
+
+const {argv, psConfig} = parse(preCommandFlags) || {}
 
 if (argv && psConfig) {
   runPackageScript({
@@ -18,6 +24,7 @@ if (argv && psConfig) {
         logLevel: argv.logLevel,
         prefix: argv.prefix,
         scripts: argv.scripts,
+        args: postCommandFlags,
       },
       psConfig.options,
     ),

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ function runPackageScript({scriptConfig, options, input}) {
       ref: 'missing-script',
     })
   }
-  const command = [script, ...args].join(' ').trim()
+  const command = [script, ...args, ...(options.args || [])].join(' ').trim()
   const log = getLogger(getLogLevel(options))
   const showScript = options.scripts
   log.info(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Follows the format specified in #139 to forward command line arguments to scripts. Notably, this disables running scripts in parallel from the command line.

<!-- Why are these changes necessary? -->
**Why**:
See discussion in #139 

<!-- How were these changes implemented? -->
**How**:
By changing the parsing of command line args in src/bin/nps.js. 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

I'd like to confirm the approach here. Specifically, I'm not sure if we should also be considering programatic use here. I thought no: I left the implementation of `runPackageScript` as is, so folks can still run scripts in parallel from the function call if they'd like to. I am assuming if someone is calling that function, they can already pass arbitrary command line args to each command just with string concatenation after a space, which is not possible from the CLI using the previous yargs parsing.

This would be a breaking change if released.

If the approach looks good, I can add documentation.